### PR TITLE
Update CI script to skip running `simple-git-hooks`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "eslint-plugin-regexp": "^1.5.1",
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "nano-staged": "^0.5.0",
-        "simple-git-hooks": "^2.7.0",
         "typescript": "^4.5.5",
         "uvu": "^0.5.3"
       },
@@ -2184,16 +2183,6 @@
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
     },
-    "node_modules/simple-git-hooks": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.7.0.tgz",
-      "integrity": "sha512-nQe6ASMO9zn5/htIrU37xEIHGr9E6wikXelLbOeTcfsX2O++DHaVug7RSQoq+kO7DvZTH37WA5gW49hN9HTDmQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "simple-git-hooks": "cli.js"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4031,12 +4020,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
-      "dev": true
-    },
-    "simple-git-hooks": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.7.0.tgz",
-      "integrity": "sha512-nQe6ASMO9zn5/htIrU37xEIHGr9E6wikXelLbOeTcfsX2O++DHaVug7RSQoq+kO7DvZTH37WA5gW49hN9HTDmQ==",
       "dev": true
     },
     "slash": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "eslint-plugin-regexp": "^1.5.1",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "nano-staged": "^0.5.0",
-    "simple-git-hooks": "^2.7.0",
     "typescript": "^4.5.5",
     "uvu": "^0.5.3"
   },

--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -5,11 +5,6 @@ const {
   INIT_CWD = '',
 } = process.env;
 
-console.debug({
-  CI,
-  INIT_CWD,
-});
-
 if (CI !== 'true') {
   const {
     name: moduleName,
@@ -19,7 +14,14 @@ if (CI !== 'true') {
     !INIT_CWD.endsWith(`node_modules/${moduleName}`) &&
     INIT_CWD.endsWith(moduleName)
   ) {
+    /**
+     * NOTE: To skip running `simple-git-hooks` in CI environment.
+     * But `npm x -y -- simple-git-hooks@latest` does not work as expected so splitting it into
+     * a 2-step process: install without saving as dependency then execute it.
+     */
+    await $`npm i --no-save simple-git-hooks`
     await $`simple-git-hooks`;
+
     await $`npm dedupe`;
   }
 }

--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -1,9 +1,14 @@
 #!/usr/bin/env zx
 
 const {
-  CI = false,
+  CI = 'false',
   INIT_CWD = '',
 } = process.env;
+
+console.debug({
+  CI,
+  INIT_CWD,
+});
 
 if (CI !== 'true') {
   const {


### PR DESCRIPTION
## Issues

`simple-git-hooks` is installed as a dev dependency and it runs its `postinstall` script everytime `npm i` or `npm ci` runs.

## Changes

1. Remove `simple-git-hooks` from `devDependencies`
1. Install `simple-git-hooks` then execute it in `postinstall.mjs`